### PR TITLE
MODIFIED: Filter Logging System Panic

### DIFF
--- a/examples/alternating_windows.rs
+++ b/examples/alternating_windows.rs
@@ -9,7 +9,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -7,7 +7,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/current_window.rs
+++ b/examples/current_window.rs
@@ -13,7 +13,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/flexbox.rs
+++ b/examples/flexbox.rs
@@ -7,7 +7,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -7,7 +7,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -7,7 +7,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::INFO).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())

--- a/examples/system_info.rs
+++ b/examples/system_info.rs
@@ -10,7 +10,11 @@ use winit::{dpi::PhysicalSize, window::WindowBuilder};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::ERROR.into())
-        .add_directive(format!("agui={}", LevelFilter::DEBUG).parse().unwrap());
+        .add_directive(
+            format!("agui={}", LevelFilter::INFO)
+                .parse()
+                .expect("Failed to parse log level directive"),
+        );
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::time())


### PR DESCRIPTION
You are calling unwrap() on the result of a parse(). The unwrap() function returns the value inside an Ok variant, but if the Result is an Err, it will cause the program to panic and terminate.

## Pull request type

Potential Bug Fix

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, calling unwrap() on the result of parse() within these filters can cause the program to panic and terminate if an Err is returned instead of the expected Ok.

Issue Number: N/A

## What is the new behavior?

- Now, it should handle an Err Result far more cleanly, with a proper error message, instead of panicing and terminating the whole program.

## Other information

N/A